### PR TITLE
fix: enlarge default window and make page layouts responsive

### DIFF
--- a/src/cibmangotree/gui/main_workflow.py
+++ b/src/cibmangotree/gui/main_workflow.py
@@ -2,6 +2,7 @@
 Main GUI workflow including all pages.
 """
 
+from nicegui import app as nicegui_app
 from nicegui import ui
 
 from cibmangotree.app import App
@@ -95,9 +96,11 @@ def gui_main(app: App):
         else:
             PlaceholderDashboard(session=gui_session).render()
 
+    nicegui_app.native.window_args["min_size"] = (1024, 710)
     ui.run(
         native=True,
         title="CIB Mango Tree",
         favicon="🥭",
         reload=False,
+        window_size=(1060, 720),
     )

--- a/src/cibmangotree/gui/pages/analysis_config_and_run.py
+++ b/src/cibmangotree/gui/pages/analysis_config_and_run.py
@@ -63,7 +63,9 @@ class AnalysisConfigAndRunPage(GuiPage):
                 f"Project '{self.session.current_project.display_name}' created successfully!"
             )
 
-        with self.centered_content(max_width="1200px", justify="start", padding="2rem"):
+        with self.centered_content(
+            max_width="1200px", justify="start", padding="2rem", height="auto"
+        ):
             with (
                 ui.stepper()
                 .props("horizontal animated")

--- a/src/cibmangotree/gui/pages/analysis_workflow/column_mapping_step.py
+++ b/src/cibmangotree/gui/pages/analysis_workflow/column_mapping_step.py
@@ -53,7 +53,11 @@ class ColumnMappingStep:
 
     def _build_column_card(self, input_col, user_columns, draft_column_mapping) -> None:
         """Build a single column mapping card."""
-        with ui.card().classes("w-52 p-4 no-shadow border border-gray-200"):
+        with (
+            ui.card()
+            .classes("p-4 no-shadow border border-gray-200")
+            .style("flex: 1 1 0; min-width: 160px")
+        ):
             with ui.row().classes("items-center gap-1"):
                 ui.label(input_col.human_readable_name_or_fallback()).classes(
                     "text-bold"

--- a/src/cibmangotree/gui/pages/start.py
+++ b/src/cibmangotree/gui/pages/start.py
@@ -66,7 +66,10 @@ class StartPage(GuiPage):
         ui.add_head_html("""
             <style>
                 .my-sticky-table {
-                    height: 310px;
+                /* Window height minus the page's fixed furniture (header, footer,
+                    padding, logo, button row = 488px). Re-measure if any of those
+                    change. Floor keeps the table usable at the minimum window size. */
+                    height: max(180px, calc(100vh - 496px));
                 }
                 .my-sticky-table thead tr th {
                     position: sticky;


### PR DESCRIPTION
## Bug: #384

The app opens at NiceGUI's default 800x600, which is smaller than the ~960px content column that every page is designed around.

- projects table was locked to 310px, now sizes to the window
- analysis stepper was locked to 80% of window height, so the footer covered the Next button; now sizes to its content
- column mapping cards were a fixed 208px each, used flex to share the row evenly

### Home Screen - Reduced to smallest size, beyond which window doesn't shrink
<img width="1051" height="750" alt="image" src="https://github.com/user-attachments/assets/e4453621-d1ba-47da-8caa-75db051e4926" />

### Map Columns Screen
<img width="1022" height="707" alt="image" src="https://github.com/user-attachments/assets/2e27903a-303f-4cfd-9c80-8364d59fca83" />


