### PR TITLE
fix: correct Windows GUI startup import

### DIFF
--- a/src/cibmangotree/__main__.py
+++ b/src/cibmangotree/__main__.py
@@ -18,7 +18,7 @@ def main() -> None:
 
     # clear Mark of the Web for Win .exe
     if sys.platform == "win32":
-        from src.cibmangotree.gui.utils import _remove_motw
+        from cibmangotree.gui.utils import _remove_motw
 
         _remove_motw()
 

--- a/src/cibmangotree/test_main.py
+++ b/src/cibmangotree/test_main.py
@@ -1,0 +1,26 @@
+import sys
+from pathlib import Path
+
+import pytest
+
+from cibmangotree import __main__
+
+
+@pytest.mark.skipif(sys.platform != "win32", reason="Windows-specific startup path")
+def test_noop_entry_point_outside_repository(monkeypatch, tmp_path):
+    """The installed entry point must not rely on the repository root."""
+    repository_root = Path(__file__).resolve().parents[2]
+    import_paths = [
+        path for path in sys.path if Path(path or ".").resolve() != repository_root
+    ]
+
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(sys, "path", import_paths)
+    monkeypatch.setattr(sys, "argv", ["cibmt", "--noop"])
+    monkeypatch.delitem(sys.modules, "src", raising=False)
+    monkeypatch.delitem(sys.modules, "src.cibmangotree", raising=False)
+
+    with pytest.raises(SystemExit) as exit_info:
+        __main__.main()
+
+    assert exit_info.value.code == 0


### PR DESCRIPTION
## Summary

- Correct the Windows-only startup import to use the installed `cibmangotree` package namespace.
- Add a Windows regression test that verifies the entry point does not depend on the repository root being on `sys.path`.

## Problem

The development GUI failed to launch on Windows with:

```text
ModuleNotFoundError: No module named 'src'